### PR TITLE
Fix XGBoostError caused by incorrect model path in run_model.py

### DIFF
--- a/Run/run_model.py
+++ b/Run/run_model.py
@@ -4,7 +4,7 @@ import numpy as np
 
 # Path to the pre-trained XGBoost model (JSON format)
 # IMPORTANT: Ensure this path points to your specific model file
-MODEL_PATH = "xgboost_model_default.json"
+MODEL_PATH = "Run/xgboost_model_default.json"
 
 # Load the saved XGBoost model
 best_model = xgb.Booster()


### PR DESCRIPTION
## Description

Corrected ```MODEL_PATH``` in ```run_model.py``` from ```xgboost_model_default.json``` to ```Run/xgboost_model_default.json```.

## Issue

Closes #2 

## Additional Notes

This fix resolves the ```xgboost.core.XGBoostError``` that occurred when following the README instructions.
